### PR TITLE
Count visits with our own Umami, and say so

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -7,7 +7,7 @@
    only for annotation. Red never fills a button and never sets a word of type.
    =========================================================================== */
 
-/* ---------- Fonts (self-hosted: the page promises no third parties) -------- */
+/* ---------- Fonts (self-hosted: no font CDN gets to see a visitor) --------- */
 @font-face {
   font-family: 'Archivo';
   font-style: normal;

--- a/index.html
+++ b/index.html
@@ -27,6 +27,12 @@
   <meta name="twitter:description" content="Marked-up photos in a branded PDF, made on site, in under a minute. One payment. No subscription." />
   <meta name="twitter:image" content="https://provaro.12f.dk/assets/og/og-image.png" />
 
+  <!-- Umami: self-hosted on our own box, cookie-less, no cross-site identifier.
+       It is the only request this page makes to anywhere but itself, which is
+       why the fonts below it are self-hosted and the closing fineprint says
+       plainly that visits are counted. -->
+  <script defer src="https://umami.robert-jensen.dk/script.js" data-website-id="007e0c65-405a-4881-99a3-ca9bb0895715"></script>
+
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -545,7 +551,7 @@
               <span class="as-lg">App&nbsp;Store</span>
             </span>
           </a>
-          <p class="fineprint">Nothing on this page is an ad, and nothing about your visit is tracked.</p>
+          <p class="fineprint">Nothing on this page is an ad. Visits are counted on our own server, without cookies.</p>
         </div>
       </div>
     </section>


### PR DESCRIPTION
Closes #19.

Adds the self-hosted Umami tag to `<head>`:

    <script defer src="https://umami.robert-jensen.dk/script.js" data-website-id="007e0c65-405a-4881-99a3-ca9bb0895715"></script>

## Two claims had to change with it

The page said in two places that it talks to nobody. Umami is cookie-less and sets no cross-site identifier, but it is still the one request this page makes to anywhere but itself, so:

| Where | Was | Now |
|---|---|---|
| Closing fineprint | "Nothing on this page is an ad, and nothing about your visit is tracked." | "Nothing on this page is an ad. Visits are counted on our own server, without cookies." |
| `styles.css` fonts comment | "self-hosted: the page promises no third parties" | "self-hosted: no font CDN gets to see a visitor" |

The fonts stay self-hosted. That was always about keeping a font CDN out of the visitor's request log, and it still holds — the comment just needed to stop claiming more than it delivers.

## Verified

Loaded locally in a headless browser: `script.js` returns 200, `window.umami` is present, `/api/send` fires one pageview, no console errors. The fineprint still sets in the same block under the App Store button. (One localhost pageview will be sitting in the dashboard from that check.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LBhGTewcFU4mvcQbd5ZqRz