### PR TITLE
Put a cache key on the stylesheet

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,11 @@
 
   <link rel="preload" href="assets/fonts/archivo-400_800-latin.woff2" as="font" type="font/woff2" crossorigin />
   <link rel="preload" href="assets/fonts/ibm-plex-mono-500-latin.woff2" as="font" type="font/woff2" crossorigin />
-  <link rel="stylesheet" href="css/styles.css" />
+  <!-- BUMP ?v= WHENEVER css/styles.css CHANGES. Pages serves the stylesheet with
+       a four-hour cache and no hash in its filename, so without a fresh query the
+       new markup gets styled by the old rules for hours after a deploy. The HTML
+       itself carries a much shorter TTL, so a changed token lands immediately. -->
+  <link rel="stylesheet" href="css/styles.css?v=2026-08-16b" />
 
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="Provaro" />


### PR DESCRIPTION
Closes #23.

#21 shipped markup and CSS together, and Pages served the new HTML against the old stylesheet — so the live page had Apple's badge at its intrinsic 120x40, sitting on the white plate the previous `.appstore` rule painted behind it. Not broken; just not the design, for up to four hours.

    last-modified: Sun, 16 Aug 2026 19:33:37 GMT   <- the previous deploy
    cache-control: max-age=14400
    age: 582

The stylesheet has no hash in its filename and there is no build step here to give it one, so the version goes in the query: `css/styles.css?v=2026-08-16b`. The HTML carries a much shorter TTL, so a changed token takes effect the moment the HTML lands.

The comment above the link says to bump it whenever the stylesheet changes — it only works if that is actually done, which is why it shouts.

Verified locally: the sheet still resolves and applies (badge back to 156x52), no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LBhGTewcFU4mvcQbd5ZqRz