### PR TITLE
Name the rights holder, not the product

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,6 +46,8 @@
     "applicationCategory": "BusinessApplication",
     "url": "https://provaro.12f.dk/",
     "installUrl": "https://apps.apple.com/us/app/id6800068309",
+    "author": { "@type": "Organization", "name": "12F ApS" },
+    "publisher": { "@type": "Organization", "name": "12F ApS" },
     "description": "Turn a finished job into a professional photo report: marked-up photos in a branded PDF, made on site, in under a minute. Works offline, no account, no ads.",
     "featureList": [
       "Photograph a whole job without leaving the camera",
@@ -633,7 +635,7 @@
         <a href="#faq">Questions</a>
         <a href="https://provaro.12f.dk/privacy-policy/">Privacy policy</a>
       </nav>
-      <p class="copyright">&copy; 2026 Provaro</p>
+      <p class="copyright">&copy; 2026 12F ApS</p>
     </div>
   </footer>
 


### PR DESCRIPTION
Closes #27.

The footer read `© 2026 Provaro`. Provaro is the product; the rights holder is **12F ApS** — the spelling and capitalisation the sibling 12f sites already use.

While there: the `MobileApplication` JSON-LD said nothing about who publishes the app, so it now carries `author` and `publisher` as an `Organization` named 12F ApS. `wrnty.12f.dk` and `snapdeck.12f.dk` name the Organization the same way.

Verified locally: both JSON-LD blocks still parse, the footer reads `© 2026 12F ApS`, no console errors. No CSS changed, so the stylesheet cache key stays put.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LBhGTewcFU4mvcQbd5ZqRz