### PR TITLE
Point every App Store link at the canonical product URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
     "operatingSystem": "iOS",
     "applicationCategory": "BusinessApplication",
     "url": "https://provaro.12f.dk/",
-    "installUrl": "https://apps.apple.com/us/app/id6800068309",
+    "installUrl": "https://apps.apple.com/us/app/provaro-job-photo-reports/id6800068309",
     "author": { "@type": "Organization", "name": "12F ApS" },
     "publisher": { "@type": "Organization", "name": "12F ApS" },
     "description": "Turn a finished job into a professional photo report: marked-up photos in a branded PDF, made on site, in under a minute. Works offline, no account, no ads.",
@@ -125,7 +125,7 @@
         <a href="#pricing">Pricing</a>
         <a href="#faq">Questions</a>
       </nav>
-      <a class="header-cta" href="https://apps.apple.com/us/app/id6800068309" target="_blank" rel="noopener">Get Provaro</a>
+      <a class="header-cta" href="https://apps.apple.com/us/app/provaro-job-photo-reports/id6800068309" target="_blank" rel="noopener">Get Provaro</a>
     </div>
   </header>
 
@@ -142,7 +142,7 @@
             under a minute, with no signal and no account.
           </p>
           <div class="actions">
-            <a class="appstore" href="https://apps.apple.com/us/app/id6800068309" target="_blank" rel="noopener">
+            <a class="appstore" href="https://apps.apple.com/us/app/provaro-job-photo-reports/id6800068309" target="_blank" rel="noopener">
               <img src="assets/img/appstore-badge.svg" alt="Download on the App Store" width="120" height="40" />
             </a>
             <a class="btn btn-line" href="#report">See what your customer gets</a>
@@ -540,7 +540,7 @@
               <li><svg width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/></svg>Works fully offline</li>
               <li><svg width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/></svg>No account, no ads</li>
             </ul>
-            <a class="btn btn-line" href="https://apps.apple.com/us/app/id6800068309" target="_blank" rel="noopener">Start free</a>
+            <a class="btn btn-line" href="https://apps.apple.com/us/app/provaro-job-photo-reports/id6800068309" target="_blank" rel="noopener">Start free</a>
           </div>
           <div class="plan plan-pro">
             <span class="plan-flag">Pro &middot; one-time purchase</span>
@@ -552,7 +552,7 @@
               <li><svg width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/></svg><strong>iCloud sync across your devices</strong> — your iCloud, not a server of ours</li>
               <li><svg width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/></svg>Everything in Free</li>
             </ul>
-            <a class="appstore" href="https://apps.apple.com/us/app/id6800068309" target="_blank" rel="noopener">
+            <a class="appstore" href="https://apps.apple.com/us/app/provaro-job-photo-reports/id6800068309" target="_blank" rel="noopener">
               <img src="assets/img/appstore-badge.svg" alt="Download on the App Store" width="120" height="40" />
             </a>
             <p class="plan-note">Pro is bought inside the app.</p>
@@ -613,7 +613,7 @@
           <p class="lede">iPhone and iPad. Free to start, 19.99&nbsp;&euro; once for your branding.</p>
         </div>
         <div class="close-actions">
-          <a class="appstore" href="https://apps.apple.com/us/app/id6800068309" target="_blank" rel="noopener">
+          <a class="appstore" href="https://apps.apple.com/us/app/provaro-job-photo-reports/id6800068309" target="_blank" rel="noopener">
             <img src="assets/img/appstore-badge.svg" alt="Download on the App Store" width="120" height="40" />
           </a>
           <p class="fineprint">Nothing on this page is an ad. Visits are counted on our own server, without cookies.</p>


### PR DESCRIPTION
The site linked to the bare `id6800068309` form. Swapped all six references — JSON-LD `installUrl`, header CTA, the pricing "Start free" button and the three App Store badges — to Apple's canonical listing URL with the slug.

Note: the URL currently 404s because the app has not gone live on the store yet; it resolves once the listing publishes.

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RqaCA1VBWQQY2XG2CgWHNy