### PR TITLE
Take the price from Apple instead of typing it

### DIFF
--- a/.github/workflows/appstore-price.yml
+++ b/.github/workflows/appstore-price.yml
@@ -1,0 +1,50 @@
+name: App Store price
+
+# The prices on the page are Apple's, not ours: tools/fetch-appstore-price.py
+# reads them off the App Store and writes them into index.html and
+# assets/data/pricing.json. Apple moves them without telling us — a tier
+# repricing, a VAT change, a storefront we newly sell in — so ask once a day
+# and commit only when the answer is different. A commit to main deploys the
+# page, and IndexNow picks it up from the deployment event.
+
+on:
+  schedule:
+    - cron: '17 6 * * *'
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'tools/fetch-appstore-price.py'
+      - '.github/workflows/appstore-price.yml'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: appstore-price
+  cancel-in-progress: false
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Ask Apple what it charges
+        run: python3 tools/fetch-appstore-price.py
+
+      - name: Commit if the price moved
+        run: |
+          if git diff --quiet -- index.html assets/data/pricing.json; then
+            echo "Apple's prices are unchanged — nothing to commit."
+            exit 0
+          fi
+
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add index.html assets/data/pricing.json
+          git commit -m "Take the price Apple is actually charging
+
+          Written by tools/fetch-appstore-price.py from the App Store listing."
+          git push

--- a/assets/data/pricing.json
+++ b/assets/data/pricing.json
@@ -1,0 +1,135 @@
+{
+  "appId": "6800068309",
+  "product": "Pro (Lifetime)",
+  "primary": "ie",
+  "secondary": "dk",
+  "storefronts": {
+    "ie": {
+      "regions": [
+        "IE",
+        "AT",
+        "BE",
+        "CY",
+        "DE",
+        "EE",
+        "ES",
+        "FI",
+        "FR",
+        "GR",
+        "HR",
+        "IT",
+        "LT",
+        "LU",
+        "LV",
+        "MT",
+        "NL",
+        "PT",
+        "SI",
+        "SK"
+      ],
+      "currency": "EUR",
+      "free": "€0",
+      "pro": "€9.99",
+      "proAmount": 9.99
+    },
+    "dk": {
+      "regions": [
+        "DK"
+      ],
+      "currency": "DKK",
+      "free": "0 kr",
+      "pro": "99,00 kr",
+      "proAmount": 99.0
+    },
+    "se": {
+      "regions": [
+        "SE"
+      ],
+      "currency": "SEK",
+      "free": "0 kr",
+      "pro": "129,00 kr",
+      "proAmount": 129.0
+    },
+    "no": {
+      "regions": [
+        "NO"
+      ],
+      "currency": "NOK",
+      "free": "0 kr",
+      "pro": "129,00 kr",
+      "proAmount": 129.0
+    },
+    "gb": {
+      "regions": [
+        "GB"
+      ],
+      "currency": "GBP",
+      "free": "£0",
+      "pro": "£9.99",
+      "proAmount": 9.99
+    },
+    "us": {
+      "regions": [
+        "US"
+      ],
+      "currency": "USD",
+      "free": "$0",
+      "pro": "$9.99",
+      "proAmount": 9.99
+    },
+    "ca": {
+      "regions": [
+        "CA"
+      ],
+      "currency": "CAD",
+      "free": "$0",
+      "pro": "$12.99",
+      "proAmount": 12.99
+    },
+    "au": {
+      "regions": [
+        "AU"
+      ],
+      "currency": "AUD",
+      "free": "$0",
+      "pro": "$14.99",
+      "proAmount": 14.99
+    },
+    "nz": {
+      "regions": [
+        "NZ"
+      ],
+      "currency": "NZD",
+      "free": "$0",
+      "pro": "$19.99",
+      "proAmount": 19.99
+    },
+    "ch": {
+      "regions": [
+        "CH"
+      ],
+      "currency": "CHF",
+      "free": "CHF 0",
+      "pro": "CHF 9.00",
+      "proAmount": 9.0
+    },
+    "pl": {
+      "regions": [
+        "PL"
+      ],
+      "currency": "PLN",
+      "free": "0 zł",
+      "pro": "49,99 zł",
+      "proAmount": 49.99
+    },
+    "cz": {
+      "regions": [
+        "CZ"
+      ],
+      "currency": "CZK",
+      "free": "0 Kč",
+      "pro": "249,00 Kč",
+      "proAmount": 249.0
+    }
+  }
+}

--- a/index.html
+++ b/index.html
@@ -31,6 +31,106 @@
   <meta name="twitter:description" content="Marked-up photos in a branded PDF, made on site, in under a minute. One payment. No subscription." />
   <meta name="twitter:image" content="https://provaro.12f.dk/assets/og/og-image.png" />
 
+  <!-- Prices come from Apple, not from this file. tools/fetch-appstore-price.py
+       reads them off the App Store and bakes the euro price into the markup
+       above, so a crawler and a visitor with no JavaScript both read the real
+       number. This then swaps in the visitor's own storefront price, because a
+       Dane charged 99 kr should not be quoted euros. pricing.json is served
+       from this domain, so the promise in the closing fineprint still holds:
+       nothing here talks to anyone but us. -->
+  <script>
+    (function () {
+      var url = 'assets/data/pricing.json?v=655d8fd2';
+
+      // A regional locale is the honest signal — someone in Denmark almost
+      // always carries a -DK tag even when the interface language is English.
+      // Failing that, the time zone names the country well enough to price it.
+      var ZONES = {
+        'Europe/Copenhagen': 'dk', 'Europe/Stockholm': 'se',
+        'Europe/Oslo': 'no', 'Europe/London': 'gb', 'Europe/Zurich': 'ch',
+        'Europe/Warsaw': 'pl', 'Europe/Prague': 'cz', 'Pacific/Auckland': 'nz',
+        'America/Toronto': 'ca', 'America/Vancouver': 'ca',
+        'America/Edmonton': 'ca', 'America/Winnipeg': 'ca',
+        'America/Halifax': 'ca', 'America/St_Johns': 'ca'
+      };
+
+      function regions() {
+        var tags = (navigator.languages || [navigator.language || '']).slice(0);
+        var out = [];
+        tags.forEach(function (tag) {
+          var m = /^[a-z]{2,3}[-_](?:[A-Za-z]{4}[-_])?([A-Za-z]{2})\b/.exec(tag);
+          if (m) out.push(m[1].toUpperCase());
+        });
+        return out;
+      }
+
+      function zone() {
+        try {
+          var tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+          if (ZONES[tz]) return ZONES[tz];
+          if (/^(America|US)\//.test(tz)) return 'us';
+          if (/^Australia\//.test(tz)) return 'au';
+        } catch (e) {}
+        return null;
+      }
+
+      function pick(data) {
+        var sf = data.storefronts || {};
+        var wanted = regions();
+        for (var i = 0; i < wanted.length; i++) {
+          for (var key in sf) {
+            if (sf[key].regions.indexOf(wanted[i]) !== -1) return key;
+          }
+        }
+        var byZone = zone();
+        return sf[byZone] ? byZone : data.primary;
+      }
+
+      function apply(data) {
+        var sf = data.storefronts || {};
+        var hereKey = pick(data);
+        var here = sf[hereKey];
+        if (!here) return;
+        var home = sf[data.secondary] || here;
+
+        // The small print quotes a second currency so the number can be
+        // checked against a familiar one — kroner for the euro page, euros for
+        // a Danish visitor. To anyone billed in a third currency it is just
+        // noise, so they get the aside dropped rather than translated.
+        var other = hereKey === data.secondary ? sf[data.primary]
+                  : hereKey === data.primary ? home : null;
+
+        var aside = document.querySelector('[data-price-aside]');
+        if (aside) aside.hidden = !other;
+
+        var text = {
+          free: here.free,
+          pro: here.pro,
+          'pro-secondary': other ? other.pro : null
+        };
+
+        var spans = document.querySelectorAll('[data-price]');
+        for (var i = 0; i < spans.length; i++) {
+          var value = text[spans[i].getAttribute('data-price')];
+          if (value) spans[i].textContent = value;
+        }
+      }
+
+      var loaded = fetch(url, { cache: 'no-cache' }).then(function (r) {
+        if (!r.ok) throw new Error(r.status);
+        return r.json();
+      });
+
+      function run() { loaded.then(apply).catch(function () {}); }
+
+      if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', run);
+      } else {
+        run();
+      }
+    })();
+  </script>
+
   <!-- Umami: self-hosted on our own box, cookie-less, no cross-site identifier.
        It is the only request this page makes to anywhere but itself, which is
        why the fonts below it are self-hosted and the closing fineprint says
@@ -58,7 +158,7 @@
     ],
     "offers": [
       { "@type": "Offer", "price": "0", "priceCurrency": "EUR", "description": "Free: photograph, mark up, export and share. Not a trial." },
-      { "@type": "Offer", "price": "19.99", "priceCurrency": "EUR", "description": "Pro (Lifetime): your own branding on the report and iCloud sync across your devices. One-time purchase." }
+      { "@type": "Offer", "price": "9.99", "priceCurrency": "EUR", "description": "Pro (Lifetime): your own branding on the report and iCloud sync across your devices. One-time purchase." }
     ]
   }
   </script>
@@ -76,7 +176,7 @@
       {
         "@type": "Question",
         "name": "Is the free version a trial?",
-        "acceptedAnswer": { "@type": "Answer", "text": "No. Free is the whole job — photograph, mark up, export, share — and it does not expire. Pro is a single 19.99 EUR payment that puts your branding on the report and turns on iCloud sync. There is no renewal and nothing to cancel." }
+        "acceptedAnswer": { "@type": "Answer", "text": "No. Free is the whole job — photograph, mark up, export, share — and it does not expire. Pro is a single 9.99 EUR payment that puts your branding on the report and turns on iCloud sync. There is no renewal and nothing to cancel." }
       },
       {
         "@type": "Question",
@@ -193,7 +293,7 @@
           <span>from the last photo to a finished PDF, standing on the job</span>
         </div>
         <div class="ledger-item">
-          <strong>19.99&nbsp;&euro; once</strong>
+          <strong><span data-price="pro">€9.99</span> once</strong>
           <span>not per month and not per user — there is nothing to renew</span>
         </div>
         <div class="ledger-item">
@@ -531,7 +631,7 @@
           <div class="plan">
             <span class="plan-flag">Free</span>
             <h3>The whole job</h3>
-            <p class="plan-price">0&nbsp;&euro;<small>Not a trial. It does not expire.</small></p>
+            <p class="plan-price"><span data-price="free">€0</span><small>Not a trial. It does not expire.</small></p>
             <p class="plan-bill">Everything you need to document a job and hand the PDF over.</p>
             <ul>
               <li><svg width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/></svg>Photograph or import photos</li>
@@ -545,7 +645,7 @@
           <div class="plan plan-pro">
             <span class="plan-flag">Pro &middot; one-time purchase</span>
             <h3>Your name on the paper</h3>
-            <p class="plan-price">19.99&nbsp;&euro;<small>One time &middot; 149 DKK &middot; nothing to cancel</small></p>
+            <p class="plan-price"><span data-price="pro">€9.99</span><small>One time<span data-price-aside> &middot; <span data-price="pro-secondary">99,00&nbsp;kr</span></span> &middot; nothing to cancel</small></p>
             <p class="plan-bill">Bought once, yours for good — no renewal date to be surprised by.</p>
             <ul>
               <li><svg width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/></svg><strong>Your own branding</strong> — logo, company name, registration and contact details on every page</li>
@@ -575,7 +675,7 @@
           </details>
           <details>
             <summary>Is the free version a trial?</summary>
-            <p>No. Free is the whole job — photograph, mark up, export, share — and it doesn’t expire. Pro is a single 19.99&nbsp;&euro; payment that puts your branding on the report and turns on iCloud sync. There’s no renewal and nothing to cancel.</p>
+            <p>No. Free is the whole job — photograph, mark up, export, share — and it doesn’t expire. Pro is a single <span data-price="pro">€9.99</span> payment that puts your branding on the report and turns on iCloud sync. There’s no renewal and nothing to cancel.</p>
           </details>
           <details>
             <summary>Do I need an account?</summary>
@@ -610,7 +710,7 @@
       <div class="wrap close-inner">
         <div>
           <h2>Hand over the report before you go.</h2>
-          <p class="lede">iPhone and iPad. Free to start, 19.99&nbsp;&euro; once for your branding.</p>
+          <p class="lede">iPhone and iPad. Free to start, <span data-price="pro">€9.99</span> once for your branding.</p>
         </div>
         <div class="close-actions">
           <a class="appstore" href="https://apps.apple.com/us/app/provaro-job-photo-reports/id6800068309" target="_blank" rel="noopener">

--- a/tools/fetch-appstore-price.py
+++ b/tools/fetch-appstore-price.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Read Provaro's prices off the App Store and write them into the page.
+
+Nobody should be typing a price into index.html. Apple is the only party that
+knows what a customer is actually charged, and the number moves without asking
+us — a tier repricing, a VAT change, a new storefront. This script asks Apple
+and writes the answer into the two places the page keeps a price: the marked
+spans in index.html (what a visitor reads, and what a crawler reads with no
+JavaScript) and assets/data/pricing.json (what the inline script uses to show
+a visitor their own storefront's number).
+
+Two sources, because Apple splits the answer in two:
+
+  * The app itself is free, and the public iTunes lookup API says so.
+  * "Pro (Lifetime)" is an in-app purchase, and lookup does not report those.
+    The App Store product page does: it embeds the annotation rows as
+    {"$kind":"textPair","leadingText":"Pro (Lifetime)","trailingText":"9,99 €"}.
+    That JSON carries the price already formatted for the storefront, which is
+    exactly what we want to print, and it is language-agnostic — the German
+    page labels the section "In-App-Käufe" but the pair looks the same.
+
+Run with --check to fail instead of writing, which is what CI wants when it is
+only asking "has Apple moved?".
+"""
+
+import argparse
+import hashlib
+import json
+import pathlib
+import re
+import sys
+import urllib.error
+import urllib.request
+
+APP_ID = "6800068309"
+IAP_NAME = "Pro (Lifetime)"
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+INDEX = ROOT / "index.html"
+PRICING = ROOT / "assets" / "data" / "pricing.json"
+
+# Storefronts we publish. `primary` is the one baked into the HTML for everyone
+# who does not match a storefront below; `secondary` is the number the Pro card
+# quotes alongside it, for the home market.
+PRIMARY = "ie"     # euro, formatted the way an English page reads it
+SECONDARY = "dk"   # kroner, quoted next to it on the Pro card
+
+# Storefront -> the regions whose visitors are charged that storefront's price.
+# Region codes are what Intl/navigator.language hand us; the inline script does
+# the matching, this table only decides what we go and fetch.
+STOREFRONTS = {
+    # One euro tier covers the whole eurozone; Ireland is the storefront that
+    # prints it in English, which is the language this page is written in.
+    "ie": ["IE", "AT", "BE", "CY", "DE", "EE", "ES", "FI", "FR", "GR", "HR",
+           "IT", "LT", "LU", "LV", "MT", "NL", "PT", "SI", "SK"],
+    "dk": ["DK"],
+    "se": ["SE"],
+    "no": ["NO"],
+    "gb": ["GB"],
+    "us": ["US"],
+    "ca": ["CA"],
+    "au": ["AU"],
+    "nz": ["NZ"],
+    "ch": ["CH"],
+    "pl": ["PL"],
+    "cz": ["CZ"],
+}
+
+# Safari's UA. Apple serves the product page to anything, but a plausible
+# browser is the version that keeps getting the embedded annotation JSON.
+UA = ("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+      "AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15")
+
+
+def fetch(url):
+    req = urllib.request.Request(url, headers={"User-Agent": UA})
+    with urllib.request.urlopen(req, timeout=30) as r:
+        return r.read().decode("utf-8", "replace")
+
+
+def app_price(storefront):
+    """The price of the app download itself, from the public lookup API."""
+    data = json.loads(fetch(
+        f"https://itunes.apple.com/lookup?id={APP_ID}&country={storefront}"))
+    if not data.get("resultCount"):
+        raise LookupError(f"lookup returned nothing for {storefront!r}")
+    r = data["results"][0]
+    return {"amount": r["price"], "formatted": r["formattedPrice"],
+            "currency": r["currency"]}
+
+
+def iap_price(storefront):
+    """The formatted price of the Pro in-app purchase, off the product page."""
+    page = fetch(f"https://apps.apple.com/{storefront}/app/id{APP_ID}")
+
+    # The embedded annotation JSON, which every storefront language shares.
+    pair = re.search(
+        r'"leadingText":"%s","trailingText":"((?:[^"\\]|\\.)*)"'
+        % re.escape(IAP_NAME), page)
+    if pair:
+        return json.loads('"%s"' % pair.group(1))
+
+    # Fall back to the rendered row, in case Apple stops shipping the JSON.
+    row = re.search(
+        r'<span>%s</span>\s*<span>([^<]+)</span>' % re.escape(IAP_NAME), page)
+    if row:
+        return row.group(1)
+
+    raise LookupError(f"no {IAP_NAME!r} price on the {storefront} page")
+
+
+def numeric(formatted):
+    """9,99 € -> 9.99, 99,00 kr -> 99.0, $9.99 -> 9.99. For schema.org."""
+    m = re.search(r"\d[\d.,   ]*\d|\d", formatted)
+    if not m:
+        raise ValueError(f"no number in {formatted!r}")
+    n = re.sub(r"[   ]", "", m.group(0))
+    # Whichever separator comes last is the decimal one; the other groups.
+    if "," in n and "." in n:
+        dec = "," if n.rindex(",") > n.rindex(".") else "."
+        n = n.replace("." if dec == "," else ",", "").replace(dec, ".")
+    elif "," in n:
+        # A lone comma is decimal (9,99) unless it is grouping (1,299).
+        n = n.replace(",", "." if len(n.split(",")[-1]) != 3 else "")
+    return float(n)
+
+
+def zero_like(formatted):
+    """"€9.99" -> "€0", "99,00 kr" -> "0 kr". The free tier, in the storefront's
+    own currency, without borrowing the storefront's language: the lookup API
+    would hand us "Gratis" on the German page, which is not English."""
+    return re.sub(r"\d[\d.,   ]*\d|\d", "0", formatted, count=1)
+
+
+def collect():
+    """Everything Apple will tell us, for every storefront we publish."""
+    out = {}
+    for sf in STOREFRONTS:
+        try:
+            free, pro = app_price(sf), iap_price(sf)
+        except (urllib.error.URLError, LookupError, ValueError, KeyError) as e:
+            # One dead storefront must not cost us the other twelve. The
+            # previous value stays in pricing.json and the page is unchanged.
+            print(f"  {sf}: skipped — {e}", file=sys.stderr)
+            continue
+        # The app download is free everywhere today, and "0 €" beside the Pro
+        # price reads better than the word — but if a storefront ever charges
+        # for the download, print what Apple says it charges.
+        shown = free["formatted"] if free["amount"] else zero_like(pro)
+        out[sf] = {
+            "regions": STOREFRONTS[sf],
+            "currency": free["currency"],
+            "free": shown,
+            "pro": pro,
+            "proAmount": numeric(pro),
+        }
+        print(f"  {sf}: free {shown}, pro {pro}")
+    return out
+
+
+def nbsp(price):
+    """Keep the number and its currency on one line, the way the page does."""
+    return re.sub(r"[   ]", "&nbsp;", price.strip())
+
+
+def rewrite(html, prices, version):
+    """Put the fetched numbers into every marked price in the page.
+
+    Each price in index.html is wrapped in <span data-price="free|pro">, and
+    the JSON-LD offers carry the same amounts. Both are replaced here, so the
+    page is right before a single line of JavaScript runs.
+    """
+    primary, secondary = prices[PRIMARY], prices[SECONDARY]
+
+    subs = {
+        "free": nbsp(primary["free"]),
+        "pro": nbsp(primary["pro"]),
+        "pro-secondary": nbsp(secondary["pro"]),
+    }
+
+    def span(m):
+        key = m.group(2)
+        if key not in subs:
+            raise KeyError(f'unknown data-price="{key}" in index.html')
+        return f'{m.group("open")}{subs[key]}</span>'
+
+    html, n = re.subn(
+        r'(?P<open><span[^>]*\bdata-price="([a-z-]+)"[^>]*>).*?</span>',
+        span, html)
+    if n == 0:
+        raise SystemExit("index.html has no data-price spans to fill in")
+    print(f"  rewrote {n} price spans")
+
+    # schema.org wants a bare amount and an ISO currency, not a formatted one.
+    amount = f'{primary["proAmount"]:g}'
+    html = re.sub(r'("@type": "Offer", "price": ")[^"]*(", "priceCurrency": ")'
+                  r'[^"]*(", "description": "Pro)',
+                  rf'\g<1>{amount}\g<2>{primary["currency"]}\g<3>', html)
+    html = re.sub(r'("@type": "Offer", "price": ")[^"]*(", "priceCurrency": ")'
+                  r'[^"]*(", "description": "Free)',
+                  rf'\g<1>0\g<2>{primary["currency"]}\g<3>', html)
+
+    # The FAQ answer in JSON-LD spells the price out in prose, so it needs the
+    # amount and the currency code the way a person would say them.
+    spoken = f'{amount} {primary["currency"]}'
+    html = re.sub(r"(Pro is a single )[^ ]+ [A-Z]{3}( payment)",
+                  rf"\g<1>{spoken}\g<2>", html)
+
+    # Pages serves pricing.json without a hash in its name, so the inline
+    # script would keep reading a cached copy after a price change. The token
+    # is the payload's own digest: it moves only when the prices move.
+    html = re.sub(r"(assets/data/pricing\.json\?v=)[^']*",
+                  rf"\g<1>{version}", html)
+
+    return html
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--check", action="store_true",
+                    help="fail if the page is out of date, write nothing")
+    args = ap.parse_args()
+
+    print("Asking Apple:")
+    prices = collect()
+    for sf in (PRIMARY, SECONDARY):
+        if sf not in prices:
+            raise SystemExit(
+                f"the {sf} storefront is what the page is built from and it "
+                f"could not be read — refusing to write a half-answer")
+
+    payload = json.dumps({"appId": APP_ID, "product": IAP_NAME,
+                          "primary": PRIMARY, "secondary": SECONDARY,
+                          "storefronts": prices},
+                         ensure_ascii=False, indent=2) + "\n"
+    version = hashlib.sha256(payload.encode("utf-8")).hexdigest()[:8]
+
+    before = INDEX.read_text(encoding="utf-8")
+    after = rewrite(before, prices, version)
+    was = PRICING.read_text(encoding="utf-8") if PRICING.exists() else ""
+
+    stale = after != before or payload != was
+    if args.check:
+        print("out of date" if stale else "up to date")
+        return 1 if stale else 0
+
+    if after != before:
+        INDEX.write_text(after, encoding="utf-8")
+        print(f"  wrote {INDEX.relative_to(ROOT)}")
+    if payload != was:
+        PRICING.parent.mkdir(parents=True, exist_ok=True)
+        PRICING.write_text(payload, encoding="utf-8")
+        print(f"  wrote {PRICING.relative_to(ROOT)}")
+    if not stale:
+        print("  nothing changed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #31.

The page quoted **19.99 € once** in seven places, all typed by hand. Apple charges **9.99 €** — 99 kr in Denmark, $9.99 in the States. We were quoting double the real price to every visitor, and shipping the same wrong number to Google in the `Offer` and FAQ schema.

## Where the price comes from now

`tools/fetch-appstore-price.py` asks Apple:

- the download price from the public iTunes lookup API;
- the `Pro (Lifetime)` price off the App Store product page, where it is embedded as `{"$kind":"textPair","leadingText":"Pro (Lifetime)","trailingText":"9,99 €"}` — already formatted for the storefront, and language-agnostic, so the German page parses the same as the Irish one.

It writes them into the marked `data-price` spans in `index.html`, into the two JSON-LD blocks, and into `assets/data/pricing.json` for twelve storefronts.

`.github/workflows/appstore-price.yml` runs it daily and commits only when Apple's answer has actually changed. `--check` reports staleness without writing.

## What a visitor sees

The euro price stays baked into the HTML, so crawlers and no-JS visitors read the real number without running anything. An inline script then swaps in the visitor's own storefront price, resolved from their regional locale (falling back to time zone). Verified in headless Chrome:

| Locale | Pro | Small print |
|---|---|---|
| `da-DK` | 99,00 kr | · €9.99 · nothing to cancel |
| `fr-FR` | €9.99 | · 99,00 kr · nothing to cancel |
| `en-US` | $9.99 | nothing to cancel |
| `en-AU` | $14.99 | nothing to cancel |

The kroner cross-reference is dropped for anyone billed in a third currency, where it was only noise, and a Danish visitor gets the euro price there instead of kroner twice.

`pricing.json` is same-origin and carries a content-hash cache key, so the page still makes no request to anyone but us — the closing fineprint stays true.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R3ZrSFgyWFz64ro2obYF4g