### PR TITLE
Keep the ledger price at headline size

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -502,7 +502,10 @@ p { margin: 0; }
   letter-spacing: -.025em;
   line-height: 1.05;
 }
-.ledger-item span {
+/* Direct child only: the tile's caption. The headline <strong> can carry a
+   span of its own — the price, written in by tools/fetch-appstore-price.py —
+   and that one must stay headline-sized, not drop to caption grey. */
+.ledger-item > span {
   display: block;
   margin-top: 10px;
   font-size: .87rem;

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
        a four-hour cache and no hash in its filename, so without a fresh query the
        new markup gets styled by the old rules for hours after a deploy. The HTML
        itself carries a much shorter TTL, so a changed token lands immediately. -->
-  <link rel="stylesheet" href="css/styles.css?v=2026-08-16c" />
+  <link rel="stylesheet" href="css/styles.css?v=2026-08-20a" />
 
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="Provaro" />


### PR DESCRIPTION
Follow-up to #32.

`.ledger-item span` styles the caption under each tile — `.87rem`, `#A9B8CE`, `display: block`. #32 wrapped the price in a `<span data-price="pro">` so it could be written in from the App Store, and that span lives *inside* the headline `<strong>`, so it inherited the caption rules: the price rendered as small grey text stacked above a headline-sized "once".

Scoped the rule to `.ledger-item > span`, which is the caption it was always describing. Stylesheet cache key bumped per the note in `index.html`.

Before — `$9.99` in caption grey, on its own line, above a giant `once`.
After — `$9.99 once` on one line, matching "Under a minute" and "No account" beside it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R3ZrSFgyWFz64ro2obYF4g