### PR TITLE
Tag the App Store links so downloads are attributable

### DIFF
--- a/de/index.html
+++ b/de/index.html
@@ -46,7 +46,19 @@
   <meta name="twitter:description" content="Markierte Fotos in einem PDF mit Ihrem Logo, vor Ort erstellt, in unter einer Minute. Einmal zahlen. Kein Abo." />
   <meta name="twitter:image" content="https://provaro.12f.dk/assets/og/og-image.png" />
 
-  <!-- Prices come from Apple, not from this file. tools/fetch-appstore-price.py
+  <!-- Every App Store link carries ?ct=site-provaro-de&mt=8. Without it App Store
+       Connect files each download from here into one undifferentiated "Web
+       referrer" bucket; ct= fills the Campaign column instead, so the question
+       "did the site do anything" has an answer. tools/build-i18n.py appends the
+       language to the token on a translated page — site-provaro-de and the rest
+       — which is what makes the nine translations measurable separately rather
+       than as one number. Attribution only accrues from the day tagging ships;
+       there is no backfill. See issue #35.
+
+       ct is free text and capped at 40 characters, which the longest token
+       here (site-provaro-pt-br, 18) is comfortably inside.
+
+  Prices come from Apple, not from this file. tools/fetch-appstore-price.py
        reads them off the App Store and bakes the euro price into the markup
        above, so a crawler and a visitor with no JavaScript both read the real
        number. This then swaps in the visitor's own storefront price, because a
@@ -179,7 +191,7 @@
     "operatingSystem": "iOS",
     "applicationCategory": "BusinessApplication",
     "url": "https://provaro.12f.dk/de/",
-    "installUrl": "https://apps.apple.com/de/app/provaro-job-photo-reports/id6800068309",
+    "installUrl": "https://apps.apple.com/de/app/provaro-job-photo-reports/id6800068309?ct=site-provaro-de&mt=8",
     "author": {
       "@type": "Organization",
       "name": "12F ApS",
@@ -385,7 +397,7 @@
         </nav>
       </details>
       <!-- /i18n:langpick -->
-      <a class="header-cta" href="https://apps.apple.com/de/app/provaro-job-photo-reports/id6800068309" target="_blank" rel="noopener">Provaro holen</a>
+      <a class="header-cta" href="https://apps.apple.com/de/app/provaro-job-photo-reports/id6800068309?ct=site-provaro-de&amp;mt=8" target="_blank" rel="noopener">Provaro holen</a>
     </div>
   </header>
 
@@ -398,7 +410,7 @@
           <h1><span class="ln">Fotoberichte fürs Handwerk.</span> <span class="ln">Auftrag fotografieren, Nachweis übergeben.</span></h1>
           <p class="lede">Provaro ist eine App für die Fotodokumentation im Handwerk. Sie macht aus den Fotos, die Sie gerade aufgenommen haben, ein PDF mit Ihrem Logo — Pfeile auf das, worauf es ankommt, Ihr Logo oben, Ihre Daten unten. Vor Ort erstellt, in unter einer Minute, ohne Netz und ohne Konto.</p>
           <div class="actions">
-            <a class="appstore" href="https://apps.apple.com/de/app/provaro-job-photo-reports/id6800068309" target="_blank" rel="noopener">
+            <a class="appstore" href="https://apps.apple.com/de/app/provaro-job-photo-reports/id6800068309?ct=site-provaro-de&amp;mt=8" target="_blank" rel="noopener">
               <img src="../assets/img/appstore-badge-de.svg" alt="Laden im App Store" width="120" height="40" />
             </a>
             <a class="btn btn-line" href="#report">Sehen, was Ihr Kunde bekommt</a>
@@ -748,7 +760,7 @@
               <li><svg width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/></svg>Funktioniert vollständig offline</li>
               <li><svg width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/></svg>Kein Konto, keine Werbung</li>
             </ul>
-            <a class="btn btn-line" href="https://apps.apple.com/de/app/provaro-job-photo-reports/id6800068309" target="_blank" rel="noopener">Gratis anfangen</a>
+            <a class="btn btn-line" href="https://apps.apple.com/de/app/provaro-job-photo-reports/id6800068309?ct=site-provaro-de&amp;mt=8" target="_blank" rel="noopener">Gratis anfangen</a>
           </div>
           <div class="plan plan-pro">
             <span class="plan-flag">Pro &middot; einmaliger Kauf</span>
@@ -760,7 +772,7 @@
               <li><svg width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/></svg><strong>iCloud-Sync über Ihre Geräte</strong> — Ihr iCloud, kein Server von uns</li>
               <li><svg width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/></svg>Alles aus Gratis</li>
             </ul>
-            <a class="appstore" href="https://apps.apple.com/de/app/provaro-job-photo-reports/id6800068309" target="_blank" rel="noopener">
+            <a class="appstore" href="https://apps.apple.com/de/app/provaro-job-photo-reports/id6800068309?ct=site-provaro-de&amp;mt=8" target="_blank" rel="noopener">
               <img src="../assets/img/appstore-badge-de.svg" alt="Laden im App Store" width="120" height="40" />
             </a>
             <p class="plan-note">Pro wird in der App gekauft.</p>
@@ -874,7 +886,7 @@
           <p class="lede">iPhone und iPad. Gratis anfangen, <span data-price="pro">9,99 €</span> einmalig für Ihr Branding.</p>
         </div>
         <div class="close-actions">
-          <a class="appstore" href="https://apps.apple.com/de/app/provaro-job-photo-reports/id6800068309" target="_blank" rel="noopener">
+          <a class="appstore" href="https://apps.apple.com/de/app/provaro-job-photo-reports/id6800068309?ct=site-provaro-de&amp;mt=8" target="_blank" rel="noopener">
             <img src="../assets/img/appstore-badge-de.svg" alt="Laden im App Store" width="120" height="40" />
           </a>
           <p class="fineprint">Nichts auf dieser Seite ist Werbung. Besuche werden auf unserem eigenen Server gezählt, ohne Cookies.</p>

--- a/es/index.html
+++ b/es/index.html
@@ -46,7 +46,19 @@
   <meta name="twitter:description" content="Fotos anotadas en un PDF con tu marca, hecho en la obra, en menos de un minuto. Un solo pago. Sin suscripción." />
   <meta name="twitter:image" content="https://provaro.12f.dk/assets/og/og-image.png" />
 
-  <!-- Prices come from Apple, not from this file. tools/fetch-appstore-price.py
+  <!-- Every App Store link carries ?ct=site-provaro-es&mt=8. Without it App Store
+       Connect files each download from here into one undifferentiated "Web
+       referrer" bucket; ct= fills the Campaign column instead, so the question
+       "did the site do anything" has an answer. tools/build-i18n.py appends the
+       language to the token on a translated page — site-provaro-de and the rest
+       — which is what makes the nine translations measurable separately rather
+       than as one number. Attribution only accrues from the day tagging ships;
+       there is no backfill. See issue #35.
+
+       ct is free text and capped at 40 characters, which the longest token
+       here (site-provaro-pt-br, 18) is comfortably inside.
+
+  Prices come from Apple, not from this file. tools/fetch-appstore-price.py
        reads them off the App Store and bakes the euro price into the markup
        above, so a crawler and a visitor with no JavaScript both read the real
        number. This then swaps in the visitor's own storefront price, because a
@@ -179,7 +191,7 @@
     "operatingSystem": "iOS",
     "applicationCategory": "BusinessApplication",
     "url": "https://provaro.12f.dk/es/",
-    "installUrl": "https://apps.apple.com/es/app/provaro-job-photo-reports/id6800068309",
+    "installUrl": "https://apps.apple.com/es/app/provaro-job-photo-reports/id6800068309?ct=site-provaro-es&mt=8",
     "author": {
       "@type": "Organization",
       "name": "12F ApS",
@@ -385,7 +397,7 @@
         </nav>
       </details>
       <!-- /i18n:langpick -->
-      <a class="header-cta" href="https://apps.apple.com/es/app/provaro-job-photo-reports/id6800068309" target="_blank" rel="noopener">Consigue Provaro</a>
+      <a class="header-cta" href="https://apps.apple.com/es/app/provaro-job-photo-reports/id6800068309?ct=site-provaro-es&amp;mt=8" target="_blank" rel="noopener">Consigue Provaro</a>
     </div>
   </header>
 
@@ -398,7 +410,7 @@
           <h1><span class="ln">Informes fotográficos de obra.</span> <span class="ln">Fotografía el trabajo, entrega la prueba.</span></h1>
           <p class="lede">Provaro es una app de informes fotográficos de obra para profesionales de los gremios. Convierte las fotos que acabas de hacer en un PDF con tu marca: flechas sobre lo que importa, tu logo arriba, tus datos al pie. Hecho en la obra, en menos de un minuto, sin cobertura y sin cuenta.</p>
           <div class="actions">
-            <a class="appstore" href="https://apps.apple.com/es/app/provaro-job-photo-reports/id6800068309" target="_blank" rel="noopener">
+            <a class="appstore" href="https://apps.apple.com/es/app/provaro-job-photo-reports/id6800068309?ct=site-provaro-es&amp;mt=8" target="_blank" rel="noopener">
               <img src="../assets/img/appstore-badge-es.svg" alt="Consíguelo en el App Store" width="120" height="40" />
             </a>
             <a class="btn btn-line" href="#report">Mira lo que recibe tu cliente</a>
@@ -748,7 +760,7 @@
               <li><svg width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/></svg>Funciona totalmente sin conexión</li>
               <li><svg width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/></svg>Sin cuenta, sin anuncios</li>
             </ul>
-            <a class="btn btn-line" href="https://apps.apple.com/es/app/provaro-job-photo-reports/id6800068309" target="_blank" rel="noopener">Empezar gratis</a>
+            <a class="btn btn-line" href="https://apps.apple.com/es/app/provaro-job-photo-reports/id6800068309?ct=site-provaro-es&amp;mt=8" target="_blank" rel="noopener">Empezar gratis</a>
           </div>
           <div class="plan plan-pro">
             <span class="plan-flag">Pro &middot; compra única</span>
@@ -760,7 +772,7 @@
               <li><svg width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/></svg><strong>Sincronización por iCloud entre tus dispositivos</strong> — tu iCloud, no un servidor nuestro</li>
               <li><svg width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/></svg>Todo lo de Gratis</li>
             </ul>
-            <a class="appstore" href="https://apps.apple.com/es/app/provaro-job-photo-reports/id6800068309" target="_blank" rel="noopener">
+            <a class="appstore" href="https://apps.apple.com/es/app/provaro-job-photo-reports/id6800068309?ct=site-provaro-es&amp;mt=8" target="_blank" rel="noopener">
               <img src="../assets/img/appstore-badge-es.svg" alt="Consíguelo en el App Store" width="120" height="40" />
             </a>
             <p class="plan-note">Pro se compra dentro de la app.</p>
@@ -874,7 +886,7 @@
           <p class="lede">iPhone y iPad. Gratis para empezar, <span data-price="pro">9,99 €</span> una vez para tu marca.</p>
         </div>
         <div class="close-actions">
-          <a class="appstore" href="https://apps.apple.com/es/app/provaro-job-photo-reports/id6800068309" target="_blank" rel="noopener">
+          <a class="appstore" href="https://apps.apple.com/es/app/provaro-job-photo-reports/id6800068309?ct=site-provaro-es&amp;mt=8" target="_blank" rel="noopener">
             <img src="../assets/img/appstore-badge-es.svg" alt="Consíguelo en el App Store" width="120" height="40" />
           </a>
           <p class="fineprint">Nada de esta página es un anuncio. Las visitas se cuentan en nuestro propio servidor, sin cookies.</p>

--- a/fr/index.html
+++ b/fr/index.html
@@ -46,7 +46,19 @@
   <meta name="twitter:description" content="Des photos annotées dans un PDF à votre image, fait sur le chantier, en moins d'une minute. Un seul paiement. Pas d'abonnement." />
   <meta name="twitter:image" content="https://provaro.12f.dk/assets/og/og-image.png" />
 
-  <!-- Prices come from Apple, not from this file. tools/fetch-appstore-price.py
+  <!-- Every App Store link carries ?ct=site-provaro-fr&mt=8. Without it App Store
+       Connect files each download from here into one undifferentiated "Web
+       referrer" bucket; ct= fills the Campaign column instead, so the question
+       "did the site do anything" has an answer. tools/build-i18n.py appends the
+       language to the token on a translated page — site-provaro-de and the rest
+       — which is what makes the nine translations measurable separately rather
+       than as one number. Attribution only accrues from the day tagging ships;
+       there is no backfill. See issue #35.
+
+       ct is free text and capped at 40 characters, which the longest token
+       here (site-provaro-pt-br, 18) is comfortably inside.
+
+  Prices come from Apple, not from this file. tools/fetch-appstore-price.py
        reads them off the App Store and bakes the euro price into the markup
        above, so a crawler and a visitor with no JavaScript both read the real
        number. This then swaps in the visitor's own storefront price, because a
@@ -179,7 +191,7 @@
     "operatingSystem": "iOS",
     "applicationCategory": "BusinessApplication",
     "url": "https://provaro.12f.dk/fr/",
-    "installUrl": "https://apps.apple.com/fr/app/provaro-job-photo-reports/id6800068309",
+    "installUrl": "https://apps.apple.com/fr/app/provaro-job-photo-reports/id6800068309?ct=site-provaro-fr&mt=8",
     "author": {
       "@type": "Organization",
       "name": "12F ApS",
@@ -385,7 +397,7 @@
         </nav>
       </details>
       <!-- /i18n:langpick -->
-      <a class="header-cta" href="https://apps.apple.com/fr/app/provaro-job-photo-reports/id6800068309" target="_blank" rel="noopener">Obtenir Provaro</a>
+      <a class="header-cta" href="https://apps.apple.com/fr/app/provaro-job-photo-reports/id6800068309?ct=site-provaro-fr&amp;mt=8" target="_blank" rel="noopener">Obtenir Provaro</a>
     </div>
   </header>
 
@@ -398,7 +410,7 @@
           <h1><span class="ln">Rapports photo de chantier.</span> <span class="ln">Photographiez le chantier, remettez la preuve.</span></h1>
           <p class="lede">Provaro est une application de rapport photo de chantier pour les artisans. Elle transforme les photos que vous venez de prendre en un PDF à votre image — des flèches sur ce qui compte, votre logo en haut, vos coordonnées en bas. Fait sur le chantier, en moins d'une minute, sans réseau et sans compte.</p>
           <div class="actions">
-            <a class="appstore" href="https://apps.apple.com/fr/app/provaro-job-photo-reports/id6800068309" target="_blank" rel="noopener">
+            <a class="appstore" href="https://apps.apple.com/fr/app/provaro-job-photo-reports/id6800068309?ct=site-provaro-fr&amp;mt=8" target="_blank" rel="noopener">
               <img src="../assets/img/appstore-badge-fr.svg" alt="Télécharger dans l'App Store" width="127" height="40" />
             </a>
             <a class="btn btn-line" href="#report">Voir ce que reçoit votre client</a>
@@ -748,7 +760,7 @@
               <li><svg width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/></svg>Fonctionne entièrement hors ligne</li>
               <li><svg width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/></svg>Pas de compte, pas de publicité</li>
             </ul>
-            <a class="btn btn-line" href="https://apps.apple.com/fr/app/provaro-job-photo-reports/id6800068309" target="_blank" rel="noopener">Commencer gratuitement</a>
+            <a class="btn btn-line" href="https://apps.apple.com/fr/app/provaro-job-photo-reports/id6800068309?ct=site-provaro-fr&amp;mt=8" target="_blank" rel="noopener">Commencer gratuitement</a>
           </div>
           <div class="plan plan-pro">
             <span class="plan-flag">Pro &middot; achat unique</span>
@@ -760,7 +772,7 @@
               <li><svg width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/></svg><strong>Synchronisation iCloud entre vos appareils</strong> — votre iCloud, pas un serveur à nous</li>
               <li><svg width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/></svg>Tout ce qu'il y a dans Gratuit</li>
             </ul>
-            <a class="appstore" href="https://apps.apple.com/fr/app/provaro-job-photo-reports/id6800068309" target="_blank" rel="noopener">
+            <a class="appstore" href="https://apps.apple.com/fr/app/provaro-job-photo-reports/id6800068309?ct=site-provaro-fr&amp;mt=8" target="_blank" rel="noopener">
               <img src="../assets/img/appstore-badge-fr.svg" alt="Télécharger dans l'App Store" width="127" height="40" />
             </a>
             <p class="plan-note">Pro s'achète dans l'app.</p>
@@ -874,7 +886,7 @@
           <p class="lede">iPhone et iPad. Gratuit pour commencer, <span data-price="pro">9,99 €</span> une fois pour votre image.</p>
         </div>
         <div class="close-actions">
-          <a class="appstore" href="https://apps.apple.com/fr/app/provaro-job-photo-reports/id6800068309" target="_blank" rel="noopener">
+          <a class="appstore" href="https://apps.apple.com/fr/app/provaro-job-photo-reports/id6800068309?ct=site-provaro-fr&amp;mt=8" target="_blank" rel="noopener">
             <img src="../assets/img/appstore-badge-fr.svg" alt="Télécharger dans l'App Store" width="127" height="40" />
           </a>
           <p class="fineprint">Rien sur cette page n'est une publicité. Les visites sont comptées sur notre propre serveur, sans cookies.</p>

--- a/index.html
+++ b/index.html
@@ -46,7 +46,19 @@
   <meta name="twitter:description" content="Marked-up photos in a branded PDF, made on site, in under a minute. One payment. No subscription." />
   <meta name="twitter:image" content="https://provaro.12f.dk/assets/og/og-image.png" />
 
-  <!-- Prices come from Apple, not from this file. tools/fetch-appstore-price.py
+  <!-- Every App Store link carries ?ct=site-provaro&mt=8. Without it App Store
+       Connect files each download from here into one undifferentiated "Web
+       referrer" bucket; ct= fills the Campaign column instead, so the question
+       "did the site do anything" has an answer. tools/build-i18n.py appends the
+       language to the token on a translated page — site-provaro-de and the rest
+       — which is what makes the nine translations measurable separately rather
+       than as one number. Attribution only accrues from the day tagging ships;
+       there is no backfill. See issue #35.
+
+       ct is free text and capped at 40 characters, which the longest token
+       here (site-provaro-pt-br, 18) is comfortably inside.
+
+  Prices come from Apple, not from this file. tools/fetch-appstore-price.py
        reads them off the App Store and bakes the euro price into the markup
        above, so a crawler and a visitor with no JavaScript both read the real
        number. This then swaps in the visitor's own storefront price, because a
@@ -179,7 +191,7 @@
     "operatingSystem": "iOS",
     "applicationCategory": "BusinessApplication",
     "url": "https://provaro.12f.dk/",
-    "installUrl": "https://apps.apple.com/us/app/provaro-job-photo-reports/id6800068309",
+    "installUrl": "https://apps.apple.com/us/app/provaro-job-photo-reports/id6800068309?ct=site-provaro&mt=8",
     "author": { "@type": "Organization", "name": "12F ApS", "url": "https://www.12f.dk/", "email": "provaro@12f.dk", "sameAs": ["https://www.12f.dk/provaro/", "https://apps.apple.com/gb/developer/robert-jensen/id1786807724"] },
     "publisher": { "@type": "Organization", "name": "12F ApS", "url": "https://www.12f.dk/", "email": "provaro@12f.dk" },
     "dateModified": "2026-08-27",
@@ -323,7 +335,7 @@
         </nav>
       </details>
       <!-- /i18n:langpick -->
-      <a class="header-cta" href="https://apps.apple.com/us/app/provaro-job-photo-reports/id6800068309" target="_blank" rel="noopener">Get Provaro</a>
+      <a class="header-cta" href="https://apps.apple.com/us/app/provaro-job-photo-reports/id6800068309?ct=site-provaro&amp;mt=8" target="_blank" rel="noopener">Get Provaro</a>
     </div>
   </header>
 
@@ -341,7 +353,7 @@
             no account.
           </p>
           <div class="actions">
-            <a class="appstore" href="https://apps.apple.com/us/app/provaro-job-photo-reports/id6800068309" target="_blank" rel="noopener">
+            <a class="appstore" href="https://apps.apple.com/us/app/provaro-job-photo-reports/id6800068309?ct=site-provaro&amp;mt=8" target="_blank" rel="noopener">
               <img src="assets/img/appstore-badge.svg" alt="Download on the App Store" width="120" height="40" />
             </a>
             <a class="btn btn-line" href="#report">See what your customer gets</a>
@@ -742,7 +754,7 @@
               <li><svg width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/></svg>Works fully offline</li>
               <li><svg width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/></svg>No account, no ads</li>
             </ul>
-            <a class="btn btn-line" href="https://apps.apple.com/us/app/provaro-job-photo-reports/id6800068309" target="_blank" rel="noopener">Start free</a>
+            <a class="btn btn-line" href="https://apps.apple.com/us/app/provaro-job-photo-reports/id6800068309?ct=site-provaro&amp;mt=8" target="_blank" rel="noopener">Start free</a>
           </div>
           <div class="plan plan-pro">
             <span class="plan-flag">Pro &middot; one-time purchase</span>
@@ -754,7 +766,7 @@
               <li><svg width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/></svg><strong>iCloud sync across your devices</strong> — your iCloud, not a server of ours</li>
               <li><svg width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/></svg>Everything in Free</li>
             </ul>
-            <a class="appstore" href="https://apps.apple.com/us/app/provaro-job-photo-reports/id6800068309" target="_blank" rel="noopener">
+            <a class="appstore" href="https://apps.apple.com/us/app/provaro-job-photo-reports/id6800068309?ct=site-provaro&amp;mt=8" target="_blank" rel="noopener">
               <img src="assets/img/appstore-badge.svg" alt="Download on the App Store" width="120" height="40" />
             </a>
             <p class="plan-note">Pro is bought inside the app.</p>
@@ -868,7 +880,7 @@
           <p class="lede">iPhone and iPad. Free to start, <span data-price="pro">€9.99</span> once for your branding.</p>
         </div>
         <div class="close-actions">
-          <a class="appstore" href="https://apps.apple.com/us/app/provaro-job-photo-reports/id6800068309" target="_blank" rel="noopener">
+          <a class="appstore" href="https://apps.apple.com/us/app/provaro-job-photo-reports/id6800068309?ct=site-provaro&amp;mt=8" target="_blank" rel="noopener">
             <img src="assets/img/appstore-badge.svg" alt="Download on the App Store" width="120" height="40" />
           </a>
           <p class="fineprint">Nothing on this page is an ad. Visits are counted on our own server, without cookies.</p>

--- a/it/index.html
+++ b/it/index.html
@@ -46,7 +46,19 @@
   <meta name="twitter:description" content="Foto annotate in un PDF con il tuo marchio, fatto in cantiere, in meno di un minuto. Un pagamento solo. Nessun abbonamento." />
   <meta name="twitter:image" content="https://provaro.12f.dk/assets/og/og-image.png" />
 
-  <!-- Prices come from Apple, not from this file. tools/fetch-appstore-price.py
+  <!-- Every App Store link carries ?ct=site-provaro-it&mt=8. Without it App Store
+       Connect files each download from here into one undifferentiated "Web
+       referrer" bucket; ct= fills the Campaign column instead, so the question
+       "did the site do anything" has an answer. tools/build-i18n.py appends the
+       language to the token on a translated page — site-provaro-de and the rest
+       — which is what makes the nine translations measurable separately rather
+       than as one number. Attribution only accrues from the day tagging ships;
+       there is no backfill. See issue #35.
+
+       ct is free text and capped at 40 characters, which the longest token
+       here (site-provaro-pt-br, 18) is comfortably inside.
+
+  Prices come from Apple, not from this file. tools/fetch-appstore-price.py
        reads them off the App Store and bakes the euro price into the markup
        above, so a crawler and a visitor with no JavaScript both read the real
        number. This then swaps in the visitor's own storefront price, because a
@@ -179,7 +191,7 @@
     "operatingSystem": "iOS",
     "applicationCategory": "BusinessApplication",
     "url": "https://provaro.12f.dk/it/",
-    "installUrl": "https://apps.apple.com/it/app/provaro-job-photo-reports/id6800068309",
+    "installUrl": "https://apps.apple.com/it/app/provaro-job-photo-reports/id6800068309?ct=site-provaro-it&mt=8",
     "author": {
       "@type": "Organization",
       "name": "12F ApS",
@@ -385,7 +397,7 @@
         </nav>
       </details>
       <!-- /i18n:langpick -->
-      <a class="header-cta" href="https://apps.apple.com/it/app/provaro-job-photo-reports/id6800068309" target="_blank" rel="noopener">Scarica Provaro</a>
+      <a class="header-cta" href="https://apps.apple.com/it/app/provaro-job-photo-reports/id6800068309?ct=site-provaro-it&amp;mt=8" target="_blank" rel="noopener">Scarica Provaro</a>
     </div>
   </header>
 
@@ -398,7 +410,7 @@
           <h1><span class="ln">Rapportini fotografici di cantiere.</span> <span class="ln">Fotografa il lavoro, consegna la prova.</span></h1>
           <p class="lede">Provaro è un'app per il rapportino fotografico di cantiere, fatta per gli artigiani. Trasforma le foto che hai appena scattato in un PDF con il tuo marchio: frecce su ciò che conta, il tuo logo in alto, i tuoi dati in fondo. Fatto in cantiere, in meno di un minuto, senza campo e senza account.</p>
           <div class="actions">
-            <a class="appstore" href="https://apps.apple.com/it/app/provaro-job-photo-reports/id6800068309" target="_blank" rel="noopener">
+            <a class="appstore" href="https://apps.apple.com/it/app/provaro-job-photo-reports/id6800068309?ct=site-provaro-it&amp;mt=8" target="_blank" rel="noopener">
               <img src="../assets/img/appstore-badge-it.svg" alt="Scarica su App Store" width="120" height="40" />
             </a>
             <a class="btn btn-line" href="#report">Guarda che cosa riceve il cliente</a>
@@ -748,7 +760,7 @@
               <li><svg width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/></svg>Funziona completamente offline</li>
               <li><svg width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/></svg>Nessun account, nessuna pubblicità</li>
             </ul>
-            <a class="btn btn-line" href="https://apps.apple.com/it/app/provaro-job-photo-reports/id6800068309" target="_blank" rel="noopener">Comincia gratis</a>
+            <a class="btn btn-line" href="https://apps.apple.com/it/app/provaro-job-photo-reports/id6800068309?ct=site-provaro-it&amp;mt=8" target="_blank" rel="noopener">Comincia gratis</a>
           </div>
           <div class="plan plan-pro">
             <span class="plan-flag">Pro &middot; acquisto una tantum</span>
@@ -760,7 +772,7 @@
               <li><svg width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/></svg><strong>Sincronizzazione iCloud tra i tuoi dispositivi</strong> — il tuo iCloud, non un server nostro</li>
               <li><svg width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/></svg>Tutto quello che c'è in Gratis</li>
             </ul>
-            <a class="appstore" href="https://apps.apple.com/it/app/provaro-job-photo-reports/id6800068309" target="_blank" rel="noopener">
+            <a class="appstore" href="https://apps.apple.com/it/app/provaro-job-photo-reports/id6800068309?ct=site-provaro-it&amp;mt=8" target="_blank" rel="noopener">
               <img src="../assets/img/appstore-badge-it.svg" alt="Scarica su App Store" width="120" height="40" />
             </a>
             <p class="plan-note">Pro si compra dentro l'app.</p>
@@ -874,7 +886,7 @@
           <p class="lede">iPhone e iPad. Gratis per cominciare, <span data-price="pro">9,99 €</span> una volta per il tuo marchio.</p>
         </div>
         <div class="close-actions">
-          <a class="appstore" href="https://apps.apple.com/it/app/provaro-job-photo-reports/id6800068309" target="_blank" rel="noopener">
+          <a class="appstore" href="https://apps.apple.com/it/app/provaro-job-photo-reports/id6800068309?ct=site-provaro-it&amp;mt=8" target="_blank" rel="noopener">
             <img src="../assets/img/appstore-badge-it.svg" alt="Scarica su App Store" width="120" height="40" />
           </a>
           <p class="fineprint">Niente in questa pagina è pubblicità. Le visite vengono contate sul nostro server, senza cookie.</p>

--- a/ja/index.html
+++ b/ja/index.html
@@ -46,7 +46,19 @@
   <meta name="twitter:description" content="マークアップした写真を自社ロゴ入りの PDF に。現場で、1分もかからずに。買い切り。サブスクなし。" />
   <meta name="twitter:image" content="https://provaro.12f.dk/assets/og/og-image.png" />
 
-  <!-- Prices come from Apple, not from this file. tools/fetch-appstore-price.py
+  <!-- Every App Store link carries ?ct=site-provaro-ja&mt=8. Without it App Store
+       Connect files each download from here into one undifferentiated "Web
+       referrer" bucket; ct= fills the Campaign column instead, so the question
+       "did the site do anything" has an answer. tools/build-i18n.py appends the
+       language to the token on a translated page — site-provaro-de and the rest
+       — which is what makes the nine translations measurable separately rather
+       than as one number. Attribution only accrues from the day tagging ships;
+       there is no backfill. See issue #35.
+
+       ct is free text and capped at 40 characters, which the longest token
+       here (site-provaro-pt-br, 18) is comfortably inside.
+
+  Prices come from Apple, not from this file. tools/fetch-appstore-price.py
        reads them off the App Store and bakes the euro price into the markup
        above, so a crawler and a visitor with no JavaScript both read the real
        number. This then swaps in the visitor's own storefront price, because a
@@ -179,7 +191,7 @@
     "operatingSystem": "iOS",
     "applicationCategory": "BusinessApplication",
     "url": "https://provaro.12f.dk/ja/",
-    "installUrl": "https://apps.apple.com/jp/app/provaro-job-photo-reports/id6800068309",
+    "installUrl": "https://apps.apple.com/jp/app/provaro-job-photo-reports/id6800068309?ct=site-provaro-ja&mt=8",
     "author": {
       "@type": "Organization",
       "name": "12F ApS",
@@ -385,7 +397,7 @@
         </nav>
       </details>
       <!-- /i18n:langpick -->
-      <a class="header-cta" href="https://apps.apple.com/jp/app/provaro-job-photo-reports/id6800068309" target="_blank" rel="noopener">Provaro を入手</a>
+      <a class="header-cta" href="https://apps.apple.com/jp/app/provaro-job-photo-reports/id6800068309?ct=site-provaro-ja&amp;mt=8" target="_blank" rel="noopener">Provaro を入手</a>
     </div>
   </header>
 
@@ -398,7 +410,7 @@
           <h1><span class="ln">工事写真の報告書。</span> <span class="ln">現場を撮って、証拠を渡す。</span></h1>
           <p class="lede">Provaro は、職人のための工事写真・現場写真の報告書アプリです。撮ったばかりの写真を自社ロゴ入りの PDF に変えます。要点には矢印、上にはロゴ、下には連絡先。現場で、1分もかからずに、電波もアカウントもなしで仕上がります。</p>
           <div class="actions">
-            <a class="appstore" href="https://apps.apple.com/jp/app/provaro-job-photo-reports/id6800068309" target="_blank" rel="noopener">
+            <a class="appstore" href="https://apps.apple.com/jp/app/provaro-job-photo-reports/id6800068309?ct=site-provaro-ja&amp;mt=8" target="_blank" rel="noopener">
               <img src="../assets/img/appstore-badge-ja.svg" alt="App Store からダウンロード" width="109" height="40" />
             </a>
             <a class="btn btn-line" href="#report">お客さまに届くものを見る</a>
@@ -748,7 +760,7 @@
               <li><svg width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/></svg>完全にオフラインで動作</li>
               <li><svg width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/></svg>アカウントなし、広告なし</li>
             </ul>
-            <a class="btn btn-line" href="https://apps.apple.com/jp/app/provaro-job-photo-reports/id6800068309" target="_blank" rel="noopener">無料で始める</a>
+            <a class="btn btn-line" href="https://apps.apple.com/jp/app/provaro-job-photo-reports/id6800068309?ct=site-provaro-ja&amp;mt=8" target="_blank" rel="noopener">無料で始める</a>
           </div>
           <div class="plan plan-pro">
             <span class="plan-flag">Pro &middot; 買い切り</span>
@@ -760,7 +772,7 @@
               <li><svg width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/></svg><strong>端末間の iCloud 同期</strong> — 自分の iCloud であって、当社のサーバーではありません</li>
               <li><svg width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/></svg>無料版のすべて</li>
             </ul>
-            <a class="appstore" href="https://apps.apple.com/jp/app/provaro-job-photo-reports/id6800068309" target="_blank" rel="noopener">
+            <a class="appstore" href="https://apps.apple.com/jp/app/provaro-job-photo-reports/id6800068309?ct=site-provaro-ja&amp;mt=8" target="_blank" rel="noopener">
               <img src="../assets/img/appstore-badge-ja.svg" alt="App Store からダウンロード" width="109" height="40" />
             </a>
             <p class="plan-note">Pro はアプリ内で購入します。</p>
@@ -874,7 +886,7 @@
           <p class="lede">iPhone と iPad に対応。無料で始めて、自社ブランドは <span data-price="pro">¥1,500</span> の買い切りです。</p>
         </div>
         <div class="close-actions">
-          <a class="appstore" href="https://apps.apple.com/jp/app/provaro-job-photo-reports/id6800068309" target="_blank" rel="noopener">
+          <a class="appstore" href="https://apps.apple.com/jp/app/provaro-job-photo-reports/id6800068309?ct=site-provaro-ja&amp;mt=8" target="_blank" rel="noopener">
             <img src="../assets/img/appstore-badge-ja.svg" alt="App Store からダウンロード" width="109" height="40" />
           </a>
           <p class="fineprint">このページに広告はありません。訪問数は自社サーバーで、Cookie を使わずに数えています。</p>

--- a/nl/index.html
+++ b/nl/index.html
@@ -46,7 +46,19 @@
   <meta name="twitter:description" content="Gemarkeerde foto's in een pdf met jouw huisstijl, op locatie gemaakt, in minder dan een minuut. Eén keer betalen. Geen abonnement." />
   <meta name="twitter:image" content="https://provaro.12f.dk/assets/og/og-image.png" />
 
-  <!-- Prices come from Apple, not from this file. tools/fetch-appstore-price.py
+  <!-- Every App Store link carries ?ct=site-provaro-nl&mt=8. Without it App Store
+       Connect files each download from here into one undifferentiated "Web
+       referrer" bucket; ct= fills the Campaign column instead, so the question
+       "did the site do anything" has an answer. tools/build-i18n.py appends the
+       language to the token on a translated page — site-provaro-de and the rest
+       — which is what makes the nine translations measurable separately rather
+       than as one number. Attribution only accrues from the day tagging ships;
+       there is no backfill. See issue #35.
+
+       ct is free text and capped at 40 characters, which the longest token
+       here (site-provaro-pt-br, 18) is comfortably inside.
+
+  Prices come from Apple, not from this file. tools/fetch-appstore-price.py
        reads them off the App Store and bakes the euro price into the markup
        above, so a crawler and a visitor with no JavaScript both read the real
        number. This then swaps in the visitor's own storefront price, because a
@@ -179,7 +191,7 @@
     "operatingSystem": "iOS",
     "applicationCategory": "BusinessApplication",
     "url": "https://provaro.12f.dk/nl/",
-    "installUrl": "https://apps.apple.com/nl/app/provaro-job-photo-reports/id6800068309",
+    "installUrl": "https://apps.apple.com/nl/app/provaro-job-photo-reports/id6800068309?ct=site-provaro-nl&mt=8",
     "author": {
       "@type": "Organization",
       "name": "12F ApS",
@@ -385,7 +397,7 @@
         </nav>
       </details>
       <!-- /i18n:langpick -->
-      <a class="header-cta" href="https://apps.apple.com/nl/app/provaro-job-photo-reports/id6800068309" target="_blank" rel="noopener">Download Provaro</a>
+      <a class="header-cta" href="https://apps.apple.com/nl/app/provaro-job-photo-reports/id6800068309?ct=site-provaro-nl&amp;mt=8" target="_blank" rel="noopener">Download Provaro</a>
     </div>
   </header>
 
@@ -398,7 +410,7 @@
           <h1><span class="ln">Fotorapportages voor de klus.</span> <span class="ln">Fotografeer de klus, geef het bewijs mee.</span></h1>
           <p class="lede">Provaro is een app voor fotorapportages en werkbonnen, gemaakt voor vakmensen. Het maakt van de foto's die je net hebt genomen een pdf met jouw huisstijl: pijlen op wat telt, jouw logo bovenaan, jouw gegevens onderaan. Op locatie gemaakt, in minder dan een minuut, zonder bereik en zonder account.</p>
           <div class="actions">
-            <a class="appstore" href="https://apps.apple.com/nl/app/provaro-job-photo-reports/id6800068309" target="_blank" rel="noopener">
+            <a class="appstore" href="https://apps.apple.com/nl/app/provaro-job-photo-reports/id6800068309?ct=site-provaro-nl&amp;mt=8" target="_blank" rel="noopener">
               <img src="../assets/img/appstore-badge-nl.svg" alt="Download in de App Store" width="120" height="40" />
             </a>
             <a class="btn btn-line" href="#report">Bekijk wat je klant krijgt</a>
@@ -748,7 +760,7 @@
               <li><svg width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/></svg>Werkt volledig offline</li>
               <li><svg width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/></svg>Geen account, geen advertenties</li>
             </ul>
-            <a class="btn btn-line" href="https://apps.apple.com/nl/app/provaro-job-photo-reports/id6800068309" target="_blank" rel="noopener">Gratis beginnen</a>
+            <a class="btn btn-line" href="https://apps.apple.com/nl/app/provaro-job-photo-reports/id6800068309?ct=site-provaro-nl&amp;mt=8" target="_blank" rel="noopener">Gratis beginnen</a>
           </div>
           <div class="plan plan-pro">
             <span class="plan-flag">Pro &middot; eenmalige aankoop</span>
@@ -760,7 +772,7 @@
               <li><svg width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/></svg><strong>iCloud-synchronisatie tussen je apparaten</strong> — jouw iCloud, geen server van ons</li>
               <li><svg width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/></svg>Alles uit Gratis</li>
             </ul>
-            <a class="appstore" href="https://apps.apple.com/nl/app/provaro-job-photo-reports/id6800068309" target="_blank" rel="noopener">
+            <a class="appstore" href="https://apps.apple.com/nl/app/provaro-job-photo-reports/id6800068309?ct=site-provaro-nl&amp;mt=8" target="_blank" rel="noopener">
               <img src="../assets/img/appstore-badge-nl.svg" alt="Download in de App Store" width="120" height="40" />
             </a>
             <p class="plan-note">Pro koop je in de app.</p>
@@ -874,7 +886,7 @@
           <p class="lede">iPhone en iPad. Gratis om te beginnen, <span data-price="pro">€ 9,99</span> eenmalig voor je huisstijl.</p>
         </div>
         <div class="close-actions">
-          <a class="appstore" href="https://apps.apple.com/nl/app/provaro-job-photo-reports/id6800068309" target="_blank" rel="noopener">
+          <a class="appstore" href="https://apps.apple.com/nl/app/provaro-job-photo-reports/id6800068309?ct=site-provaro-nl&amp;mt=8" target="_blank" rel="noopener">
             <img src="../assets/img/appstore-badge-nl.svg" alt="Download in de App Store" width="120" height="40" />
           </a>
           <p class="fineprint">Niets op deze pagina is een advertentie. Bezoeken worden geteld op onze eigen server, zonder cookies.</p>

--- a/pl/index.html
+++ b/pl/index.html
@@ -46,7 +46,19 @@
   <meta name="twitter:description" content="Zdjęcia z zaznaczeniami w PDF-ie z Twoim logo, zrobionym na miejscu, w mniej niż minutę. Jedna płatność. Bez abonamentu." />
   <meta name="twitter:image" content="https://provaro.12f.dk/assets/og/og-image.png" />
 
-  <!-- Prices come from Apple, not from this file. tools/fetch-appstore-price.py
+  <!-- Every App Store link carries ?ct=site-provaro-pl&mt=8. Without it App Store
+       Connect files each download from here into one undifferentiated "Web
+       referrer" bucket; ct= fills the Campaign column instead, so the question
+       "did the site do anything" has an answer. tools/build-i18n.py appends the
+       language to the token on a translated page — site-provaro-de and the rest
+       — which is what makes the nine translations measurable separately rather
+       than as one number. Attribution only accrues from the day tagging ships;
+       there is no backfill. See issue #35.
+
+       ct is free text and capped at 40 characters, which the longest token
+       here (site-provaro-pt-br, 18) is comfortably inside.
+
+  Prices come from Apple, not from this file. tools/fetch-appstore-price.py
        reads them off the App Store and bakes the euro price into the markup
        above, so a crawler and a visitor with no JavaScript both read the real
        number. This then swaps in the visitor's own storefront price, because a
@@ -179,7 +191,7 @@
     "operatingSystem": "iOS",
     "applicationCategory": "BusinessApplication",
     "url": "https://provaro.12f.dk/pl/",
-    "installUrl": "https://apps.apple.com/pl/app/provaro-job-photo-reports/id6800068309",
+    "installUrl": "https://apps.apple.com/pl/app/provaro-job-photo-reports/id6800068309?ct=site-provaro-pl&mt=8",
     "author": {
       "@type": "Organization",
       "name": "12F ApS",
@@ -385,7 +397,7 @@
         </nav>
       </details>
       <!-- /i18n:langpick -->
-      <a class="header-cta" href="https://apps.apple.com/pl/app/provaro-job-photo-reports/id6800068309" target="_blank" rel="noopener">Pobierz Provaro</a>
+      <a class="header-cta" href="https://apps.apple.com/pl/app/provaro-job-photo-reports/id6800068309?ct=site-provaro-pl&amp;mt=8" target="_blank" rel="noopener">Pobierz Provaro</a>
     </div>
   </header>
 
@@ -398,7 +410,7 @@
           <h1><span class="ln">Raporty fotograficzne z budowy.</span> <span class="ln">Sfotografuj zlecenie, oddaj dowód.</span></h1>
           <p class="lede">Provaro to aplikacja do dokumentacji fotograficznej i raportów z budowy, zrobiona dla fachowców. Zamienia właśnie zrobione zdjęcia w PDF z Twoim logo: strzałki na tym, co ważne, logo u góry, dane firmy na dole. Powstaje na miejscu, w mniej niż minutę, bez zasięgu i bez konta.</p>
           <div class="actions">
-            <a class="appstore" href="https://apps.apple.com/pl/app/provaro-job-photo-reports/id6800068309" target="_blank" rel="noopener">
+            <a class="appstore" href="https://apps.apple.com/pl/app/provaro-job-photo-reports/id6800068309?ct=site-provaro-pl&amp;mt=8" target="_blank" rel="noopener">
               <img src="../assets/img/appstore-badge-pl.svg" alt="Pobierz z App Store" width="120" height="40" />
             </a>
             <a class="btn btn-line" href="#report">Zobacz, co dostaje klient</a>
@@ -748,7 +760,7 @@
               <li><svg width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/></svg>Działa w pełni offline</li>
               <li><svg width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/></svg>Bez konta, bez reklam</li>
             </ul>
-            <a class="btn btn-line" href="https://apps.apple.com/pl/app/provaro-job-photo-reports/id6800068309" target="_blank" rel="noopener">Zacznij za darmo</a>
+            <a class="btn btn-line" href="https://apps.apple.com/pl/app/provaro-job-photo-reports/id6800068309?ct=site-provaro-pl&amp;mt=8" target="_blank" rel="noopener">Zacznij za darmo</a>
           </div>
           <div class="plan plan-pro">
             <span class="plan-flag">Pro &middot; zakup jednorazowy</span>
@@ -760,7 +772,7 @@
               <li><svg width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/></svg><strong>Synchronizacja iCloud między urządzeniami</strong> — Twoje iCloud, a nie nasz serwer</li>
               <li><svg width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/></svg>Wszystko z wersji darmowej</li>
             </ul>
-            <a class="appstore" href="https://apps.apple.com/pl/app/provaro-job-photo-reports/id6800068309" target="_blank" rel="noopener">
+            <a class="appstore" href="https://apps.apple.com/pl/app/provaro-job-photo-reports/id6800068309?ct=site-provaro-pl&amp;mt=8" target="_blank" rel="noopener">
               <img src="../assets/img/appstore-badge-pl.svg" alt="Pobierz z App Store" width="120" height="40" />
             </a>
             <p class="plan-note">Pro kupuje się w aplikacji.</p>
@@ -874,7 +886,7 @@
           <p class="lede">iPhone i iPad. Start za darmo, <span data-price="pro">49,99 zł</span> raz za własne logo na raporcie.</p>
         </div>
         <div class="close-actions">
-          <a class="appstore" href="https://apps.apple.com/pl/app/provaro-job-photo-reports/id6800068309" target="_blank" rel="noopener">
+          <a class="appstore" href="https://apps.apple.com/pl/app/provaro-job-photo-reports/id6800068309?ct=site-provaro-pl&amp;mt=8" target="_blank" rel="noopener">
             <img src="../assets/img/appstore-badge-pl.svg" alt="Pobierz z App Store" width="120" height="40" />
           </a>
           <p class="fineprint">Nic na tej stronie nie jest reklamą. Wizyty liczymy na własnym serwerze, bez ciasteczek.</p>

--- a/pt-br/index.html
+++ b/pt-br/index.html
@@ -46,7 +46,19 @@
   <meta name="twitter:description" content="Fotos marcadas em um PDF com a sua marca, feito na obra, em menos de um minuto. Um pagamento só. Sem assinatura." />
   <meta name="twitter:image" content="https://provaro.12f.dk/assets/og/og-image.png" />
 
-  <!-- Prices come from Apple, not from this file. tools/fetch-appstore-price.py
+  <!-- Every App Store link carries ?ct=site-provaro-pt-br&mt=8. Without it App Store
+       Connect files each download from here into one undifferentiated "Web
+       referrer" bucket; ct= fills the Campaign column instead, so the question
+       "did the site do anything" has an answer. tools/build-i18n.py appends the
+       language to the token on a translated page — site-provaro-de and the rest
+       — which is what makes the nine translations measurable separately rather
+       than as one number. Attribution only accrues from the day tagging ships;
+       there is no backfill. See issue #35.
+
+       ct is free text and capped at 40 characters, which the longest token
+       here (site-provaro-pt-br, 18) is comfortably inside.
+
+  Prices come from Apple, not from this file. tools/fetch-appstore-price.py
        reads them off the App Store and bakes the euro price into the markup
        above, so a crawler and a visitor with no JavaScript both read the real
        number. This then swaps in the visitor's own storefront price, because a
@@ -179,7 +191,7 @@
     "operatingSystem": "iOS",
     "applicationCategory": "BusinessApplication",
     "url": "https://provaro.12f.dk/pt-br/",
-    "installUrl": "https://apps.apple.com/br/app/provaro-job-photo-reports/id6800068309",
+    "installUrl": "https://apps.apple.com/br/app/provaro-job-photo-reports/id6800068309?ct=site-provaro-pt-br&mt=8",
     "author": {
       "@type": "Organization",
       "name": "12F ApS",
@@ -385,7 +397,7 @@
         </nav>
       </details>
       <!-- /i18n:langpick -->
-      <a class="header-cta" href="https://apps.apple.com/br/app/provaro-job-photo-reports/id6800068309" target="_blank" rel="noopener">Baixar o Provaro</a>
+      <a class="header-cta" href="https://apps.apple.com/br/app/provaro-job-photo-reports/id6800068309?ct=site-provaro-pt-br&amp;mt=8" target="_blank" rel="noopener">Baixar o Provaro</a>
     </div>
   </header>
 
@@ -398,7 +410,7 @@
           <h1><span class="ln">Relatório fotográfico de obra.</span> <span class="ln">Fotografe o serviço, entregue a prova.</span></h1>
           <p class="lede">O Provaro é um app de relatório fotográfico de obra — o RDO do dia a dia — feito para quem executa. Ele transforma as fotos que você acabou de tirar em um PDF com a sua marca: setas no que importa, seu logo no topo, seus dados no rodapé. Feito na obra, em menos de um minuto, sem sinal e sem conta.</p>
           <div class="actions">
-            <a class="appstore" href="https://apps.apple.com/br/app/provaro-job-photo-reports/id6800068309" target="_blank" rel="noopener">
+            <a class="appstore" href="https://apps.apple.com/br/app/provaro-job-photo-reports/id6800068309?ct=site-provaro-pt-br&amp;mt=8" target="_blank" rel="noopener">
               <img src="../assets/img/appstore-badge-pt-br.svg" alt="Baixar na App Store" width="120" height="40" />
             </a>
             <a class="btn btn-line" href="#report">Veja o que o seu cliente recebe</a>
@@ -748,7 +760,7 @@
               <li><svg width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/></svg>Funciona totalmente offline</li>
               <li><svg width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/></svg>Sem conta, sem anúncios</li>
             </ul>
-            <a class="btn btn-line" href="https://apps.apple.com/br/app/provaro-job-photo-reports/id6800068309" target="_blank" rel="noopener">Comece grátis</a>
+            <a class="btn btn-line" href="https://apps.apple.com/br/app/provaro-job-photo-reports/id6800068309?ct=site-provaro-pt-br&amp;mt=8" target="_blank" rel="noopener">Comece grátis</a>
           </div>
           <div class="plan plan-pro">
             <span class="plan-flag">Pro &middot; compra única</span>
@@ -760,7 +772,7 @@
               <li><svg width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/></svg><strong>Sincronização por iCloud entre os seus aparelhos</strong> — o seu iCloud, não um servidor nosso</li>
               <li><svg width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/></svg>Tudo o que tem no Grátis</li>
             </ul>
-            <a class="appstore" href="https://apps.apple.com/br/app/provaro-job-photo-reports/id6800068309" target="_blank" rel="noopener">
+            <a class="appstore" href="https://apps.apple.com/br/app/provaro-job-photo-reports/id6800068309?ct=site-provaro-pt-br&amp;mt=8" target="_blank" rel="noopener">
               <img src="../assets/img/appstore-badge-pt-br.svg" alt="Baixar na App Store" width="120" height="40" />
             </a>
             <p class="plan-note">O Pro se compra dentro do app.</p>
@@ -874,7 +886,7 @@
           <p class="lede">iPhone e iPad. Grátis para começar, <span data-price="pro">R$ 59,90</span> uma vez para a sua marca.</p>
         </div>
         <div class="close-actions">
-          <a class="appstore" href="https://apps.apple.com/br/app/provaro-job-photo-reports/id6800068309" target="_blank" rel="noopener">
+          <a class="appstore" href="https://apps.apple.com/br/app/provaro-job-photo-reports/id6800068309?ct=site-provaro-pt-br&amp;mt=8" target="_blank" rel="noopener">
             <img src="../assets/img/appstore-badge-pt-br.svg" alt="Baixar na App Store" width="120" height="40" />
           </a>
           <p class="fineprint">Nada nesta página é anúncio. As visitas são contadas no nosso próprio servidor, sem cookies.</p>

--- a/tools/build-i18n.py
+++ b/tools/build-i18n.py
@@ -29,6 +29,10 @@ Two things are deliberately kept out of the catalogues:
 The App Store badge is artwork, not copy, so it is not in the catalogues
 either: each page is pointed at Apple's own badge for its language, at whatever
 size that badge happens to be. tools/fetch-appstore-badges.py fetches them.
+
+Nor is the App Store link. Each page points at its own storefront and carries
+its own `ct=` campaign token, so App Store Connect can say which language page
+a download came from rather than filing all nine under "Web referrer".
 """
 
 import argparse
@@ -442,6 +446,13 @@ def render(extraction, catalogue, lang, prices):
     doc = re.sub(r"      <details class=\"lang-pick\".*?</details>",
                  lambda m: langpick(lang), doc, count=1, flags=re.S)
     doc = doc.replace("apps.apple.com/us/app/", "apps.apple.com/%s/app/" % lang["store"])
+
+    # The campaign token carries the language (#35). Tagging every page
+    # `site-provaro` would answer "did the site do anything" and leave "did
+    # translating it do anything" exactly as unanswerable as before — which is
+    # the more expensive question. Prefixed rather than renamed, so a report
+    # that groups on `site-provaro` still sees the site as one thing.
+    doc = doc.replace("ct=site-provaro", "ct=site-provaro-%s" % lang["dirname"])
     doc = badge(doc, lang)
 
     # Prices: fill what the msgid blanked, then drop the second-currency aside


### PR DESCRIPTION
Closes #35.

Every download from this site lands in one undifferentiated **`Web referrer`** row. `ct=` fills Apple's Campaign column instead.

## One token per language, not one for the site

The issue was written when this was one page with one link. It's now nine pages with six links each — which changes the interesting question. Tagging everything `site-provaro` answers *"did the site do anything"* and leaves *"did translating it do anything"* exactly as unanswerable as before.

| Page | Token | Storefront |
|---|---|---|
| `/` | `site-provaro` | us |
| `/de/` | `site-provaro-de` | de |
| `/ja/` | `site-provaro-ja` | jp |
| `/pt-br/` | `site-provaro-pt-br` | br |

Prefixed rather than renamed, so a report grouping on `site-provaro` still sees the site as one thing. Longest token is 18 chars, well inside Apple's 40. The English page keeps the issue's exact token so it stays comparable with the other sites in the portfolio.

## The ampersand goes two ways

The same URL is written in two languages on the page, and they disagree:

- **href** — `&amp;mt=8`; a bare `&` is an unescaped entity reference
- **JSON-LD `installUrl`** — `&mt=8`; `&amp;` would be four literal characters in the URL Apple receives

Both ship, each where it belongs. Verified by reading `.href` back out of the DOM (browser decodes to `&mt=8`) and by re-parsing every JSON-LD block, rather than by grepping the file.

## Checked

All nine pages: one token each, 6 tagged links, 5 escaped hrefs plus the raw JSON-LD string, correct per-storefront path retained from #39. Catalogue count unchanged at 220 — the links aren't inside any translated string, so no translation work was needed.

## Two things to actually do

1. **Look at the Campaign column in ~2 days.** The issue is explicit that it's the check. If it's empty, add Apple's provider token as `&pt=`.
2. **Attribution starts today.** No backfill.